### PR TITLE
Support taskToRun as a command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ As seen above, there are a few different configuration options available
 To use the added `runTaskForChangedProjects` from this plugin you need to run it with a few parameters.
 The minimum required is `-PchangedProjectsTask.run` which enables the plugin to run.
 Depending on usage, it might also be a good idea to run it with `--continue` such that all dependent tasks are run, instead of fail-fast behaviour.
-Then there are three other optional parameters `-PchangedProjectsTask.commit`, `-PchangedProjectsTask.prevCommit` and `-PchangedProjectsTask.compareMode`.
+Then there are three other optional parameters `-PchangedProjectsTask.commit`, `-PchangedProjectsTask.prevCommit` and `-PchangedProjectsTask.compareMode` and `-PchangedProjectsTask.taskToRun`.
+
+- `-PchangedProjectsTask.taskToRun` let's you configure the task to run on demand. If provided, the taskToRun is not required in the config anymore. It will also have higher priority as the task provided in the configuration.
+
 
 - `-PchangedProjectsTask.commit` is to configure which ref to use in the git diff.
   - If this is specified with `-PchangedProjectsTask.prevCommit` it creates a range to use in diff.   

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'changed-projects-task'
+rootProject.name = 'changed-projects-task-plugin'
 

--- a/src/main/java/io/github/crimix/changedprojectstask/configuration/ChangedProjectsChoice.java
+++ b/src/main/java/io/github/crimix/changedprojectstask/configuration/ChangedProjectsChoice.java
@@ -4,6 +4,14 @@ package io.github.crimix.changedprojectstask.configuration;
  * The two different modes that the plugin can be used
  */
 public enum ChangedProjectsChoice {
+
+    /**
+     * Only execute task on those modules that are directly affected
+     */
     ONLY_DIRECTLY,
+
+    /**
+     * Execute task on all modules in the dependency tree that are affected
+     */
     INCLUDE_DEPENDENTS
 }

--- a/src/main/java/io/github/crimix/changedprojectstask/configuration/ChangedProjectsConfiguration.java
+++ b/src/main/java/io/github/crimix/changedprojectstask/configuration/ChangedProjectsConfiguration.java
@@ -30,7 +30,7 @@ public interface ChangedProjectsConfiguration {
     SetProperty<String> getAlwaysRunProject();
 
     /**
-     * The projects to never execute the task on even when it has not changed.
+     * The projects to never execute the task on even when it has changed.
      * @return a list of project paths
      */
     SetProperty<String> getNeverRunProject();

--- a/src/main/java/io/github/crimix/changedprojectstask/extensions/Extensions.java
+++ b/src/main/java/io/github/crimix/changedprojectstask/extensions/Extensions.java
@@ -58,7 +58,9 @@ public class Extensions {
     }
 
     /**
+     * Gets the task to run from the command line arguments if given
      *
+     * @return task to run CLI argument
      */
     public static Optional<String> getTaskToRunParameter(Project project) {
         return Optional.of(project)

--- a/src/main/java/io/github/crimix/changedprojectstask/utils/Properties.java
+++ b/src/main/java/io/github/crimix/changedprojectstask/utils/Properties.java
@@ -5,8 +5,11 @@ package io.github.crimix.changedprojectstask.utils;
  * Like -PchangedProjectsTask.enable
  */
 public class Properties {
-    public static final String ENABLE = "changedProjectsTask.run";
-    public static final String CURRENT_COMMIT = "changedProjectsTask.commit";
-    public static final String PREVIOUS_COMMIT = "changedProjectsTask.prevCommit";
-    public static final String COMMIT_MODE = "changedProjectsTask.compareMode";
+    private static final String PREFIX = "changedProjectsTask.";
+
+    public static final String ENABLE = PREFIX + "run";
+    public static final String CURRENT_COMMIT = PREFIX + "commit";
+    public static final String PREVIOUS_COMMIT = PREFIX + "prevCommit";
+    public static final String COMMIT_MODE = PREFIX + "compareMode";
+    public static final String TASK_TO_RUN = PREFIX + "taskToRun";
 }


### PR DESCRIPTION
Closes #5 

I've renamed the plugin in the settings.gradle for convenience and I'm currently using it within my project in a plugins/ directory, including it in the settings.gradle with `includeBuild "plugins/changed-projects-task-plugin"` to be able to debug it. 

If this changed name hurts the maven artifact, which I'm not sure about, it can be reverted